### PR TITLE
Adição do método converte_timestamp e alteração no converte_date

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,7 +176,11 @@ module ApplicationHelper
   end
 
   def converte_date(date)
-    date.to_date.to_s_br if date
+    date.present? ? date.to_date.to_s_br : ''
+  end
+
+  def converte_timestamp(date)
+    date.present? ? date.to_s_br : ''
   end
 
   def yes_no(bool)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -116,7 +116,13 @@
                   <div class="font-s13 text-success push-5"><%= news.decorate.link_to_author %> - publicado em <%= converte_date(news.published_at) %>
 
                   </div>
-                  <p><%= raw Truncato.truncate news.text, max_length: 30, count_tags: false%></p>
+                  <p>
+                    <% if news.teaser.present? %>
+                      <%= raw news.text %>
+                    <% else %>
+                      <%= raw Truncato.truncate news.text, max_length: 150, count_tags: false%>
+                    <% end %>
+                  </p>
                   <div class="btn-group btn-group-sm">
                     <%= news.decorate.link_to_read_more %>
                   </div>


### PR DESCRIPTION
## Summary

Issue: #253

Adicionado método helper converte_timestamp para converter uma data para string no formato data e hora.

Modificado o método helper converte_date para não retornar nil mais, retornando uma string vazia caso date.present? == false.

## Other Information

Essas alterações foram feitas para correção da issue, porém estou criando um outro PR no repo [go_blog](https://github.com/gorails/go_blog) que também é necessário para correção.